### PR TITLE
View logs state

### DIFF
--- a/web-elm/elm.json
+++ b/web-elm/elm.json
@@ -17,7 +17,6 @@
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/svg": "1.0.1",
-            "elm-community/maybe-extra": "5.2.0",
             "feathericons/elm-feather": "1.5.0",
             "joakin/elm-canvas": "4.3.0",
             "mdgriffith/elm-ui": "1.1.8",

--- a/web-elm/elm.json
+++ b/web-elm/elm.json
@@ -17,6 +17,7 @@
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/svg": "1.0.1",
+            "elm-community/maybe-extra": "5.2.0",
             "feathericons/elm-feather": "1.5.0",
             "joakin/elm-canvas": "4.3.0",
             "mdgriffith/elm-ui": "1.1.8",

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -26,7 +26,6 @@ import Icon
 import Json.Decode exposing (Decoder, Value)
 import Json.Encode exposing (Value)
 import Keyboard exposing (RawKey)
-import Maybe.Extra
 import NumberInput
 import Pivot exposing (Pivot)
 import Set exposing (Set)
@@ -1352,12 +1351,12 @@ registrationHeaderTab current registeredImages =
                 Style.white
 
         buttonAttributes =
-            if Maybe.Extra.isJust registeredImages then
-                Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot "green" |> Element.html))
-                    :: baseTabAttributes bgColor
+            if registeredImages == Nothing then
+                baseTabAttributes bgColor
 
             else
-                baseTabAttributes bgColor
+                Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot "green" |> Element.html))
+                    :: baseTabAttributes bgColor
     in
     Element.Input.button buttonAttributes
         { onPress =

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1855,10 +1855,6 @@ progressBar color progressRatio =
 
 viewLogs : Model -> Element Msg
 viewLogs ({ autoscroll, verbosity, seenLogs, notSeenLogs, registeredImages } as model) =
-    let
-        logs =
-            List.concat [ seenLogs, notSeenLogs ]
-    in
     Element.column [ width fill, height fill ]
         [ headerBar
             [ imagesHeaderTab False
@@ -1886,7 +1882,7 @@ viewLogs ({ autoscroll, verbosity, seenLogs, notSeenLogs, registeredImages } as 
                 , Element.scrollbars
                 , Element.htmlAttribute (Html.Attributes.id "logs")
                 ]
-                (List.filter (\l -> l.lvl <= verbosity) logs
+                (List.filter (\l -> l.lvl <= verbosity) seenLogs
                     |> List.reverse
                     |> List.map viewLog
                 )

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1297,16 +1297,6 @@ headerHeight =
     40
 
 
-
--- | -- headerBar : Bool -> Int -> List ( PageHeader, Bool ) -> Element Msg
--- | -- headerBar registrationState logsState pages =
--- | --     Element.row
--- | --         [ height (Element.px headerHeight)
--- | --         , centerX
--- | --         ]
--- | --         (List.map (\( page, current ) -> pageHeaderElement registrationState logsState current page) pages)
-
-
 headerBar : List (Element Msg) -> Element Msg
 headerBar pages =
     Element.row

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1444,17 +1444,17 @@ logsHeaderTab current logs =
                     , Svg.Attributes.r "5"
                     , Svg.Attributes.fill
                         (case logsState of
+                            -- Style.errorColor
                             ErrorLogs ->
                                 "rgb(180,50,50)"
 
-                            -- Style.errorColor
+                            -- Style.warningColor
                             WarningLogs ->
                                 "rgb(220,120,50)"
 
-                            -- Style.warningColor
+                            -- Style.darkGrey
                             _ ->
                                 "rgb(50,50,50)"
-                         -- Style.darkGrey
                         )
                     ]
                     []

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1349,12 +1349,6 @@ configHeaderTab current =
             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
             , padding 10
             , height (Element.px headerHeight)
-            , Element.Border.widthEach
-                { bottom = 0
-                , left = 1
-                , right = 0
-                , top = 0
-                }
             ]
     in
     Element.Input.button attributes
@@ -1398,12 +1392,6 @@ registrationHeaderTab current registeredImages =
             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
             , padding 10
             , height (Element.px headerHeight)
-            , Element.Border.widthEach
-                { bottom = 0
-                , left = 1
-                , right = 0
-                , top = 0
-                }
             ]
 
         attributesRegistration =
@@ -1412,12 +1400,6 @@ registrationHeaderTab current registeredImages =
             , height (Element.px headerHeight)
             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
             , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot |> Element.html))
-            , Element.Border.widthEach
-                { bottom = 0
-                , left = 1
-                , right = 0
-                , top = 0
-                }
             ]
     in
     Element.Input.button
@@ -1452,12 +1434,6 @@ logsHeaderTab current logs =
             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
             , padding 10
             , height (Element.px headerHeight)
-            , Element.Border.widthEach
-                { bottom = 0
-                , left = 1
-                , right = 0
-                , top = 0
-                }
             ]
 
         logsState =
@@ -1501,12 +1477,6 @@ logsHeaderTab current logs =
             -- , Element.Border.dotted
             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
             , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot |> Element.html))
-            , Element.Border.widthEach
-                { bottom = 0
-                , left = 1
-                , right = 0
-                , top = 0
-                }
             ]
     in
     Element.Input.button

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -766,22 +766,22 @@ update msg model =
             ( { model | registeredImages = Maybe.map goToNextImage model.registeredImages }, Cmd.none )
 
         ( RunAlgorithm params, ViewImgs imgs ) ->
-            ( switchToLogsPage imgs model
+            ( runAndSwitchToLogsPage imgs model
             , run (encodeParams params)
             )
 
         ( RunAlgorithm params, Config imgs ) ->
-            ( switchToLogsPage imgs model
+            ( runAndSwitchToLogsPage imgs model
             , run (encodeParams params)
             )
 
         ( RunAlgorithm params, Registration imgs ) ->
-            ( switchToLogsPage imgs model
+            ( runAndSwitchToLogsPage imgs model
             , run (encodeParams params)
             )
 
         ( RunAlgorithm params, Logs imgs ) ->
-            ( switchToLogsPage imgs model
+            ( runAndSwitchToLogsPage imgs model
             , run (encodeParams params)
             )
 
@@ -913,15 +913,9 @@ update msg model =
             ( model, Cmd.none )
 
 
-switchToLogsPage : { images : Pivot Image } -> Model -> Model
-switchToLogsPage imgs model =
-    { model
-        | state = Logs imgs
-        , registeredImages = Nothing
-        , runStep = StepNotStarted
-        , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
-        , notSeenLogs = []
-    }
+runAndSwitchToLogsPage : { images : Pivot Image } -> Model -> Model
+runAndSwitchToLogsPage imgs model =
+    goTo GoToPageLogs imgs { model | registeredImages = Nothing, runStep = StepNotStarted }
 
 
 scrollLogsToEndCmd : Cmd Msg

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1351,27 +1351,12 @@ registrationHeaderTab current registeredImages =
             else
                 Style.white
 
-        littleDot =
-            Svg.svg
-                [ Svg.Attributes.viewBox "0 0 10 10"
-                , Svg.Attributes.width "10"
-                , Svg.Attributes.height "10"
-                ]
-                [ Svg.circle
-                    [ Svg.Attributes.cx "5"
-                    , Svg.Attributes.cy "5"
-                    , Svg.Attributes.r "5"
-                    , Svg.Attributes.fill "green"
-                    ]
-                    []
-                ]
-
         attributesRegistration =
             [ Element.Background.color bgColor
             , padding 10
             , height (Element.px headerHeight)
             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
-            , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot |> Element.html))
+            , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot "green" |> Element.html))
             ]
     in
     Element.Input.button
@@ -1404,40 +1389,26 @@ logsHeaderTab current logs =
         logsState =
             getMaxLevel logs
 
-        littleDot =
-            Svg.svg
-                [ Svg.Attributes.viewBox "0 0 10 10"
-                , Svg.Attributes.width "10"
-                , Svg.Attributes.height "10"
-                ]
-                [ Svg.circle
-                    [ Svg.Attributes.cx "5"
-                    , Svg.Attributes.cy "5"
-                    , Svg.Attributes.r "5"
-                    , Svg.Attributes.fill
-                        (case logsState of
-                            -- Style.errorColor
-                            ErrorLogs ->
-                                "rgb(180,50,50)"
+        fillColor =
+            case logsState of
+                -- Style.errorColor
+                ErrorLogs ->
+                    "rgb(180,50,50)"
 
-                            -- Style.warningColor
-                            WarningLogs ->
-                                "rgb(220,120,50)"
+                -- Style.warningColor
+                WarningLogs ->
+                    "rgb(220,120,50)"
 
-                            -- Style.darkGrey
-                            _ ->
-                                "rgb(50,50,50)"
-                        )
-                    ]
-                    []
-                ]
+                -- Style.darkGrey
+                _ ->
+                    "rgb(50,50,50)"
 
         attributesLogs =
             [ Element.Background.color bgColor
             , padding 10
             , height (Element.px headerHeight)
             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
-            , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot |> Element.html))
+            , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot fillColor |> Element.html))
             ]
     in
     Element.Input.button
@@ -1465,6 +1436,23 @@ baseTabAttributes bgColor =
     , padding 10
     , height (Element.px headerHeight)
     ]
+
+
+littleDot : String -> Html msg
+littleDot fillColor =
+    Svg.svg
+        [ Svg.Attributes.viewBox "0 0 10 10"
+        , Svg.Attributes.width "10"
+        , Svg.Attributes.height "10"
+        ]
+        [ Svg.circle
+            [ Svg.Attributes.cx "5"
+            , Svg.Attributes.cy "5"
+            , Svg.Attributes.r "5"
+            , Svg.Attributes.fill fillColor
+            ]
+            []
+        ]
 
 
 

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -556,16 +556,16 @@ update msg model =
             ( { model | paramsInfo = updateParamsInfo paramsInfoMsg model.paramsInfo }, Cmd.none )
 
         ( NavigationMsg navMsg, ViewImgs data ) ->
-            ( goTo navMsg model data, Cmd.none )
+            ( goTo navMsg data model, Cmd.none )
 
         ( NavigationMsg navMsg, Config data ) ->
-            ( goTo navMsg model data, Cmd.none )
+            ( goTo navMsg data model, Cmd.none )
 
         ( NavigationMsg navMsg, Registration data ) ->
-            ( goTo navMsg model data, Cmd.none )
+            ( goTo navMsg data model, Cmd.none )
 
         ( NavigationMsg navMsg, Logs data ) ->
-            ( goTo navMsg model data, Cmd.none )
+            ( goTo navMsg data model, Cmd.none )
 
         ( ZoomMsg zoomMsg, ViewImgs _ ) ->
             ( { model | viewer = zoomViewer zoomMsg model.viewer }, Cmd.none )
@@ -1018,8 +1018,8 @@ zoomViewer msg viewer =
             Viewer.zoomAwayFrom coordinates viewer
 
 
-goTo : NavigationMsg -> Model -> { images : Pivot Image } -> Model
-goTo msg model data =
+goTo : NavigationMsg -> { images : Pivot Image } -> Model -> Model
+goTo msg data model =
     case msg of
         GoToPageImages ->
             { model | state = ViewImgs data, pointerMode = WaitingMove }

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1350,15 +1350,16 @@ registrationHeaderTab current registeredImages =
 
             else
                 Style.white
-    in
-    Element.Input.button
-        (if Maybe.Extra.isJust registeredImages then
-            Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot "green" |> Element.html))
-                :: baseTabAttributes bgColor
 
-         else
-            baseTabAttributes bgColor
-        )
+        buttonAttributes =
+            if Maybe.Extra.isJust registeredImages then
+                Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot "green" |> Element.html))
+                    :: baseTabAttributes bgColor
+
+            else
+                baseTabAttributes bgColor
+    in
+    Element.Input.button buttonAttributes
         { onPress =
             if current then
                 Nothing
@@ -1395,16 +1396,17 @@ logsHeaderTab current logs =
                 -- Style.darkGrey
                 _ ->
                     "rgb(50,50,50)"
-    in
-    Element.Input.button
-        (case logsState of
-            NoLogs ->
-                baseTabAttributes bgColor
 
-            _ ->
-                Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot fillColor |> Element.html))
-                    :: baseTabAttributes bgColor
-        )
+        buttonAttributes =
+            case logsState of
+                NoLogs ->
+                    baseTabAttributes bgColor
+
+                _ ->
+                    Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot fillColor |> Element.html))
+                        :: baseTabAttributes bgColor
+    in
+    Element.Input.button buttonAttributes
         { onPress =
             if current then
                 Nothing

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1027,7 +1027,7 @@ goTo msg data model =
         GoToPageLogs ->
             { model
                 | state = Logs data
-                , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
+                , seenLogs = List.concat [ model.notSeenLogs, model.seenLogs ]
                 , notSeenLogs = []
             }
 

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -2016,11 +2016,7 @@ verbositySlider verbosity =
 
 
 viewRegistration : Model -> Element Msg
-viewRegistration ({ registeredImages, registeredViewer, seenLogs, notSeenLogs } as model) =
-    let
-        logs =
-            List.concat [ seenLogs, notSeenLogs ]
-    in
+viewRegistration ({ registeredImages, registeredViewer, notSeenLogs } as model) =
     Element.column [ width fill, height fill ]
         [ headerBar
             [ imagesHeaderTab False
@@ -2115,11 +2111,7 @@ viewRegistration ({ registeredImages, registeredViewer, seenLogs, notSeenLogs } 
 
 
 viewConfig : Model -> Element Msg
-viewConfig ({ params, paramsForm, paramsInfo, seenLogs, notSeenLogs, registeredImages } as model) =
-    let
-        logs =
-            List.concat [ seenLogs, notSeenLogs ]
-    in
+viewConfig ({ params, paramsForm, paramsInfo, notSeenLogs, registeredImages } as model) =
     Element.column [ width fill, height fill ]
         [ headerBar
             [ imagesHeaderTab False
@@ -2596,11 +2588,8 @@ toggleCheckboxWidget { offColor, onColor, sliderColor, toggleWidth, toggleHeight
 
 
 viewImgs : Model -> Pivot Image -> Element Msg
-viewImgs ({ pointerMode, bboxDrawn, viewer, seenLogs, notSeenLogs, registeredImages } as model) images =
+viewImgs ({ pointerMode, bboxDrawn, viewer, notSeenLogs, registeredImages } as model) images =
     let
-        logs =
-            List.concat [ seenLogs, notSeenLogs ]
-
         img =
             Pivot.getC images
 

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -766,46 +766,22 @@ update msg model =
             ( { model | registeredImages = Maybe.map goToNextImage model.registeredImages }, Cmd.none )
 
         ( RunAlgorithm params, ViewImgs imgs ) ->
-            ( { model
-                | state = Logs imgs
-                , registeredImages = Nothing
-                , runStep = StepNotStarted
-                , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
-                , notSeenLogs = []
-              }
+            ( switchToLogsPage imgs model
             , run (encodeParams params)
             )
 
         ( RunAlgorithm params, Config imgs ) ->
-            ( { model
-                | state = Logs imgs
-                , registeredImages = Nothing
-                , runStep = StepNotStarted
-                , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
-                , notSeenLogs = []
-              }
+            ( switchToLogsPage imgs model
             , run (encodeParams params)
             )
 
         ( RunAlgorithm params, Registration imgs ) ->
-            ( { model
-                | state = Logs imgs
-                , registeredImages = Nothing
-                , runStep = StepNotStarted
-                , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
-                , notSeenLogs = []
-              }
+            ( switchToLogsPage imgs model
             , run (encodeParams params)
             )
 
         ( RunAlgorithm params, Logs imgs ) ->
-            ( { model
-                | state = Logs imgs
-                , registeredImages = Nothing
-                , runStep = StepNotStarted
-                , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
-                , notSeenLogs = []
-              }
+            ( switchToLogsPage imgs model
             , run (encodeParams params)
             )
 
@@ -935,6 +911,17 @@ update msg model =
 
         _ ->
             ( model, Cmd.none )
+
+
+switchToLogsPage : { images : Pivot Image } -> Model -> Model
+switchToLogsPage imgs model =
+    { model
+        | state = Logs imgs
+        , registeredImages = Nothing
+        , runStep = StepNotStarted
+        , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
+        , notSeenLogs = []
+    }
 
 
 scrollLogsToEndCmd : Cmd Msg

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -777,13 +777,37 @@ update msg model =
             )
 
         ( RunAlgorithm params, Config imgs ) ->
-            ( { model | state = Logs imgs, registeredImages = Nothing, runStep = StepNotStarted, seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ], notSeenLogs = [] }, run (encodeParams params) )
+            ( { model
+                | state = Logs imgs
+                , registeredImages = Nothing
+                , runStep = StepNotStarted
+                , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
+                , notSeenLogs = []
+              }
+            , run (encodeParams params)
+            )
 
         ( RunAlgorithm params, Registration imgs ) ->
-            ( { model | state = Logs imgs, registeredImages = Nothing, runStep = StepNotStarted, seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ], notSeenLogs = [] }, run (encodeParams params) )
+            ( { model
+                | state = Logs imgs
+                , registeredImages = Nothing
+                , runStep = StepNotStarted
+                , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
+                , notSeenLogs = []
+              }
+            , run (encodeParams params)
+            )
 
         ( RunAlgorithm params, Logs imgs ) ->
-            ( { model | state = Logs imgs, registeredImages = Nothing, runStep = StepNotStarted, seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ], notSeenLogs = [] }, run (encodeParams params) )
+            ( { model
+                | state = Logs imgs
+                , registeredImages = Nothing
+                , runStep = StepNotStarted
+                , seenLogs = List.concat [ model.seenLogs, model.notSeenLogs ]
+                , notSeenLogs = []
+              }
+            , run (encodeParams params)
+            )
 
         ( StopRunning, _ ) ->
             ( { model | runStep = StepNotStarted }, stop () )

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1308,15 +1308,8 @@ imagesHeaderTab current =
 
             else
                 Style.white
-
-        attributes =
-            [ Element.Background.color bgColor
-            , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
-            , padding 10
-            , height (Element.px headerHeight)
-            ]
     in
-    Element.Input.button attributes
+    Element.Input.button (baseTabAttributes bgColor)
         { onPress =
             if current then
                 Nothing
@@ -1336,15 +1329,8 @@ configHeaderTab current =
 
             else
                 Style.white
-
-        attributes =
-            [ Element.Background.color bgColor
-            , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
-            , padding 10
-            , height (Element.px headerHeight)
-            ]
     in
-    Element.Input.button attributes
+    Element.Input.button (baseTabAttributes bgColor)
         { onPress =
             if current then
                 Nothing
@@ -1380,13 +1366,6 @@ registrationHeaderTab current registeredImages =
                     []
                 ]
 
-        attributes =
-            [ Element.Background.color bgColor
-            , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
-            , padding 10
-            , height (Element.px headerHeight)
-            ]
-
         attributesRegistration =
             [ Element.Background.color bgColor
             , padding 10
@@ -1400,7 +1379,7 @@ registrationHeaderTab current registeredImages =
             attributesRegistration
 
          else
-            attributes
+            baseTabAttributes bgColor
         )
         { onPress =
             if current then
@@ -1421,13 +1400,6 @@ logsHeaderTab current logs =
 
             else
                 Style.white
-
-        attributes =
-            [ Element.Background.color bgColor
-            , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
-            , padding 10
-            , height (Element.px headerHeight)
-            ]
 
         logsState =
             getMaxLevel logs
@@ -1471,7 +1443,7 @@ logsHeaderTab current logs =
     Element.Input.button
         (case logsState of
             NoLogs ->
-                attributes
+                baseTabAttributes bgColor
 
             _ ->
                 attributesLogs
@@ -1484,6 +1456,15 @@ logsHeaderTab current logs =
                 Just (NavigationMsg GoToPageLogs)
         , label = Element.text "Logs"
         }
+
+
+baseTabAttributes : Element.Color -> List (Element.Attribute msg)
+baseTabAttributes bgColor =
+    [ Element.Background.color bgColor
+    , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
+    , padding 10
+    , height (Element.px headerHeight)
+    ]
 
 
 

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1283,13 +1283,6 @@ viewElmUI model =
 -- Header
 
 
-type PageHeader
-    = PageImages
-    | PageConfig
-    | PageRegistration
-    | PageLogs
-
-
 {-| WARNING: this has to be kept consistent with the text size in the header
 -}
 headerHeight : Int
@@ -1471,10 +1464,6 @@ logsHeaderTab current logs =
             [ Element.Background.color bgColor
             , padding 10
             , height (Element.px headerHeight)
-
-            -- , Element.Border.widthXY 0 4
-            -- , Element.Border.color borderColor
-            -- , Element.Border.dotted
             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
             , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot |> Element.html))
             ]
@@ -1498,107 +1487,6 @@ logsHeaderTab current logs =
 
 
 
--- | -- pageHeaderElement : Bool -> Int -> Bool -> PageHeader -> Element Msg
--- | -- pageHeaderElement registrationState logsState current page =
--- | --     let
--- | --         bgColor =
--- | --             if current then
--- | --                 Style.almostWhite
--- | --
--- | --             else
--- | --                 Style.white
--- | --
--- | --         attributes =
--- | --             [ Element.Background.color bgColor
--- | --             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
--- | --             , padding 10
--- | --             , height (Element.px headerHeight)
--- | --             ]
--- | --
--- | --         borderColor =
--- | --             case logsState of
--- | --                 0 ->
--- | --                     Style.errorColor
--- | --
--- | --                 1 ->
--- | --                     Style.warningColor
--- | --
--- | --                 _ ->
--- | --                     Style.black
--- | --
--- | --         attributesRegistration =
--- | --             [ Element.Background.color Style.green
--- | --             , padding 10
--- | --             , height (Element.px headerHeight)
--- | --             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
--- | --             ]
--- | --
--- | --         attributesLogs =
--- | --             [ Element.Background.color bgColor
--- | --             , padding 10
--- | --             , height (Element.px headerHeight)
--- | --             , Element.Border.width 4
--- | --             , Element.Border.color borderColor
--- | --             , Element.Border.dotted
--- | --             , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
--- | --             ]
--- | --     in
--- | --     case page of
--- | --         PageImages ->
--- | --             Element.Input.button attributes
--- | --                 { onPress =
--- | --                     if current then
--- | --                         Nothing
--- | --
--- | --                     else
--- | --                         Just (NavigationMsg GoToPageImages)
--- | --                 , label = Element.text "Images"
--- | --                 }
--- | --
--- | --         PageConfig ->
--- | --             Element.Input.button attributes
--- | --                 { onPress =
--- | --                     if current then
--- | --                         Nothing
--- | --
--- | --                     else
--- | --                         Just (NavigationMsg GoToPageConfig)
--- | --                 , label = Element.text "Config"
--- | --                 }
--- | --
--- | --         PageRegistration ->
--- | --             Element.Input.button
--- | --                 (if registrationState then
--- | --                     attributesRegistration
--- | --
--- | --                  else
--- | --                     attributes
--- | --                 )
--- | --                 { onPress =
--- | --                     if current then
--- | --                         Nothing
--- | --
--- | --                     else
--- | --                         Just (NavigationMsg GoToPageRegistration)
--- | --                 , label = Element.text "Registration"
--- | --                 }
--- | --
--- | --         PageLogs ->
--- | --             Element.Input.button
--- | --                 (if logsState == 2 then
--- | --                     attributes
--- | --
--- | --                  else
--- | --                     attributesLogs
--- | --                 )
--- | --                 { onPress =
--- | --                     if current then
--- | --                         Nothing
--- | --
--- | --                     else
--- | --                         Just (NavigationMsg GoToPageLogs)
--- | --                 , label = Element.text "Logs"
--- | --                 }
 -- Run progress
 
 

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1350,18 +1350,11 @@ registrationHeaderTab current registeredImages =
 
             else
                 Style.white
-
-        attributesRegistration =
-            [ Element.Background.color bgColor
-            , padding 10
-            , height (Element.px headerHeight)
-            , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
-            , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot "green" |> Element.html))
-            ]
     in
     Element.Input.button
         (if Maybe.Extra.isJust registeredImages then
-            attributesRegistration
+            Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot "green" |> Element.html))
+                :: baseTabAttributes bgColor
 
          else
             baseTabAttributes bgColor
@@ -1402,14 +1395,6 @@ logsHeaderTab current logs =
                 -- Style.darkGrey
                 _ ->
                     "rgb(50,50,50)"
-
-        attributesLogs =
-            [ Element.Background.color bgColor
-            , padding 10
-            , height (Element.px headerHeight)
-            , Element.htmlAttribute <| Html.Attributes.style "box-shadow" "none"
-            , Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot fillColor |> Element.html))
-            ]
     in
     Element.Input.button
         (case logsState of
@@ -1417,7 +1402,8 @@ logsHeaderTab current logs =
                 baseTabAttributes bgColor
 
             _ ->
-                attributesLogs
+                Element.inFront (Element.el [ alignRight, padding 2 ] (littleDot fillColor |> Element.html))
+                    :: baseTabAttributes bgColor
         )
         { onPress =
             if current then


### PR DESCRIPTION
# Visual indicators for presence of data in pages

Some minor changes are shown here, regarding the buttons of the *logs* page and the *registration* page.
The goal was for them to show some *visual hints* about the *content* of their related pages.

## Two buttons changed :

Initially, the two buttons went from `white` to `almostWhite` colors when clicked, as shown bellow :
![clean_logs_and_reg](https://user-images.githubusercontent.com/85450305/121659314-79171280-caa2-11eb-8247-80e01dc2cc18.png)

Now the registration button goes from `white`/`almostWhite` to `green` when the registered images are *ready* :
![green_reg_and_dark_logs](https://user-images.githubusercontent.com/85450305/121659356-8207e400-caa2-11eb-8240-45b7558447b8.png)

In addition to that, when logs appear the logs button's border goes from empty to dotted :
![dark_logs](https://user-images.githubusercontent.com/85450305/121659342-7e745d00-caa2-11eb-88b2-3a9b90bce88b.png)

It can also go to red `errorColor` when at least one error-log appears in the logs
![reg_green_and_logs_red](https://user-images.githubusercontent.com/85450305/121659319-7a483f80-caa2-11eb-9a61-302360f4eec2.png)


## Mechanisms :

### For the register button :

The `registeredImages` data-structure is a `Maybe (Pivot Image)`, so when the images have all gone through the _rank-reduction algorithm_, the `Model` field goes from `Nothing` to `Just (Pivot Image)`.

We use the `Maybe.Extra` package, which provides the function `isJust` that lets us know if the images are loaded in the `Registration` page or not.

### For the logs button

We have a new function `getMaxLevel` to know in a list of logs if one of them is an error :red_circle:.
We use this function to render the `headerBar` in each window, as an `Int` parameter.
It could be upgraded by using the adventages of *Elm* to make an adapted structure instead of an `Int`