### PR TITLE
Prevent bad loading

### DIFF
--- a/lowrr-wasm/src/lib.rs
+++ b/lowrr-wasm/src/lib.rs
@@ -107,6 +107,8 @@ impl LowrrInner {
             .expect("Cursor io never fails");
         // let image = reader.decode().expect("Error decoding the image");
         let dyn_img = reader.decode().map_err(utils::report_error)?;
+        let reported_err =
+            |str_msg: &str| Err(utils::report_error(anyhow::anyhow!(str_msg.to_string())));
 
         match (&dyn_img, &mut self.dataset) {
             // Loading the first image (empty dataset)
@@ -153,13 +155,19 @@ impl LowrrInner {
                 imgs.push(dyn_img.into_dmatrix());
                 self.image_ids.push(id);
             }
-            (DynamicImage::ImageBgr8(_), _) => return Err("BGR order not supported".into()),
-            (DynamicImage::ImageBgra8(_), _) => return Err("BGR order not supported".into()),
-            (DynamicImage::ImageLumaA8(_), _) => return Err("Alpha channel not supported".into()),
-            (DynamicImage::ImageLumaA16(_), _) => return Err("Alpha channel not supported".into()),
-            (DynamicImage::ImageRgba8(_), _) => return Err("Alpha channel not supported".into()),
-            (DynamicImage::ImageRgba16(_), _) => return Err("Alpha channel not supported".into()),
-            _ => return Err("Images are not all of the same type".into()),
+            (DynamicImage::ImageBgr8(_), _) => return reported_err("BGR order not supported"),
+            (DynamicImage::ImageBgra8(_), _) => return reported_err("Alpha channel not supported"),
+            (DynamicImage::ImageLumaA8(_), _) => {
+                return reported_err("Alpha channel not supported")
+            }
+            (DynamicImage::ImageLumaA16(_), _) => {
+                return reported_err("Alpha channel not supported")
+            }
+            (DynamicImage::ImageRgba8(_), _) => return reported_err("Alpha channel not supported"),
+            (DynamicImage::ImageRgba16(_), _) => {
+                return reported_err("Alpha channel not supported")
+            }
+            _ => return reported_err("Images are not all of the same type"),
         }
 
         Ok(())

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -1304,7 +1304,7 @@ viewElmUI model =
             viewHome model draggingState
 
         Loading loadData ->
-            viewLoading model loadData
+            viewLoading loadData
 
         ViewImgs { images } ->
             viewImgs model images
@@ -2670,8 +2670,8 @@ viewHome model draggingState =
         ]
 
 
-viewLoading : Model -> { names : Set String, loaded : Dict String Image } -> Element Msg
-viewLoading model { names, loaded } =
+viewLoading : { names : Set String, loaded : Dict String Image } -> Element Msg
+viewLoading { names, loaded } =
     let
         totalCount =
             Set.size names
@@ -2687,35 +2687,6 @@ viewLoading model { names, loaded } =
                 [ Element.el loadingBoxBorderAttributes (loadBar loadCount totalCount)
                 , Element.el [ centerX ] (Element.text ("Loading " ++ String.fromInt totalCount ++ " images"))
                 ]
-            )
-        , Element.column
-            [ padding 18
-            , height fill
-            , width fill
-            , centerX
-            , centerY
-            , Style.fontMonospace
-            , Element.Font.size 14
-            , Element.scrollbars
-            , Element.htmlAttribute (Html.Attributes.id "logs")
-            ]
-            (List.filter (\l -> l.lvl == 0) model.notSeenLogs
-                |> List.reverse
-                |> List.map viewLog
-                |> List.append
-                    [ Element.row [ padding 10 ]
-                        [ Element.Input.button
-                            [ Element.Background.color Style.almostWhite
-                            , padding 9
-                            , Element.Border.dotted
-                            , Element.Border.width 2
-                            ]
-                            { onPress = Just ReturnHome
-                            , label = Element.text "Woops, stop and reload the page"
-                            }
-                        ]
-                    , clearLogsButton
-                    ]
             )
         ]
 

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -2,6 +2,7 @@ port module Main exposing (main)
 
 import Browser
 import Browser.Dom
+import Browser.Navigation
 import Canvas
 import Canvas.Settings
 import Canvas.Settings.Advanced
@@ -941,7 +942,7 @@ update msg model =
             ( model, saveRegisteredImages model.imagesCount )
 
         ( ReturnHome, _ ) ->
-            ( { model | state = Home Idle }, Cmd.none )
+            ( model, Browser.Navigation.reload )
 
         ( ClearLogs, _ ) ->
             ( { model
@@ -2774,9 +2775,8 @@ viewLoading model { names, loaded } =
                             , Element.Border.width 2
                             ]
                             { onPress = Just ReturnHome
-                            , label = Element.text "Return home"
+                            , label = Element.text "Woops, stop and reload the page"
                             }
-                        , Element.el [ padding 10 ] (Element.text "Return home, forgetting the loaded images.")
                         ]
                     , clearLogsButton
                     ]

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -500,7 +500,7 @@ update msg model =
 
                 ( newState, cmd, errorLogs ) =
                     if List.isEmpty otherFiles then
-                        ( Home Idle
+                        ( LoadingError
                         , Cmd.none
                         , [ { lvl = 0, content = "Only 1 image was selected. Please pick at least 2." } ]
                         )
@@ -1301,7 +1301,7 @@ viewElmUI : Model -> Element Msg
 viewElmUI model =
     case model.state of
         Home draggingState ->
-            viewHome model draggingState
+            viewHome draggingState
 
         Loading loadData ->
             viewLoading loadData
@@ -2606,37 +2606,11 @@ zoomWheelMsg viewer event =
         ZoomMsg (ZoomToward coordinates)
 
 
-viewHome : Model -> FileDraggingState -> Element Msg
-viewHome model draggingState =
-    let
-        errorLogs =
-            case logsStatus model.notSeenLogs of
-                ErrorLogs ->
-                    Element.column
-                        [ padding 18
-                        , height fill
-                        , width fill
-                        , centerX
-                        , centerY
-                        , Style.fontMonospace
-                        , Element.Font.size 14
-                        , Element.scrollbars
-                        , Element.htmlAttribute (Html.Attributes.id "logs")
-                        ]
-                        (List.filter (\l -> l.lvl == 0) model.notSeenLogs
-                            |> List.reverse
-                            |> List.map viewLog
-                            |> List.append
-                                [ clearLogsButton ]
-                        )
-
-                _ ->
-                    Element.none
-    in
+viewHome : FileDraggingState -> Element Msg
+viewHome draggingState =
     Element.column (padding 20 :: width fill :: height fill :: onDropAttributes)
         [ viewTitle
         , dropAndLoadArea draggingState
-        , errorLogs
         ]
 
 

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -2658,6 +2658,16 @@ viewLoading { names, loaded } =
                 , Element.el [ centerX ] (Element.text ("Loading " ++ String.fromInt totalCount ++ " images"))
                 ]
             )
+        , Element.Input.button
+            [ Element.Background.color Style.almostWhite
+            , Element.Border.dotted
+            , Element.Border.width 2
+            , padding 16
+            , centerX
+            ]
+            { onPress = Just ReturnHome
+            , label = Element.text "Woops, stop and reload the page"
+            }
         ]
 
 


### PR DESCRIPTION
# Prevent user from misusing the loading functions

## Strategy :

We let the user go back to the home screen, with an error message.

## Messages :

* When the user tries to *load a single file*, it will get the following message :
![single_file_load](https://user-images.githubusercontent.com/85450305/121696103-04f16480-cacc-11eb-8667-2be46912aa43.png)

* When the user tries to load a *bad file format*, if rust is able to send the appropriate log (some next feature could be to verify that every bad image format is well detected by a rust error), while the file is loading the following logs will appear :
![bad_format](https://user-images.githubusercontent.com/85450305/121696386-4f72e100-cacc-11eb-8ae0-64bc16d52532.png)

* Any other error logs appearing during the loading wil get in this logs section of the loading screen.

## Navigation options

* A button lets the user go back to home screen to try other files. Another one lets it clear the logs definitely too.

:warning: When error logs appear during the loading, if they are not explicitely cleared during that phase, they remain visible on the logs screen of the app after. So thanks to the functionality of the visual marker of the logs in the `headerBar` ( #10 ) we have a red alert visible for the user.
I can't tell if it is relevant or not, maybe the error logs should be removed after coming for the first time in the second section of the app, I prefer letting the app owner choose.