### PR TITLE
[Automatic pyramids levels fit]

### DIFF
--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -544,19 +544,22 @@ update msg model =
                     , loaded = newLoaded
                     }
 
+                finished = (Set.size names == Dict.size newLoaded)
+
                 oldParamsForm =
                     model.paramsForm
 
                 oldParams =
                     model.params
 
-                optiLevels =
-                    getOptimumPyramids newLoaded
+                optiLevels = if finished
+                    then getOptimumPyramids newLoaded
+                    else model.params.levels
 
                 anyInt =
                     NumberInput.intDefault
             in
-            if Set.size names == Dict.size newLoaded then
+            if finished then
                 case Dict.values newLoaded of
                     [] ->
                         -- This should be impossible, there must be at least 1 image

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -203,6 +203,7 @@ type alias ParametersForm =
     , maxIterations : NumberInput.Field Int NumberInput.IntError
     , convergenceThreshold : NumberInput.Field Float NumberInput.FloatError
     , levels : NumberInput.Field Int NumberInput.IntError
+    , defaultLevels : Int
     , sparse : NumberInput.Field Float NumberInput.FloatError
     , lambda : NumberInput.Field Float NumberInput.FloatError
     , rho : NumberInput.Field Float NumberInput.FloatError
@@ -300,6 +301,7 @@ defaultParamsForm =
     , levels =
         { anyInt | min = Just 1, max = Just 10 }
             |> NumberInput.setDefaultIntValue defaultParams.levels
+    , defaultLevels = 0
     , sparse =
         { anyFloat | min = Just 0.0, max = Just 1.0 }
             |> NumberInput.setDefaultFloatValue defaultParams.sparse
@@ -579,6 +581,7 @@ update msg model =
                                             , max = Just 10
                                         }
                                             |> NumberInput.setDefaultIntValue optiLevels
+                                    , defaultLevels = optiLevels
                                 }
                             , imagesCount = Set.size names
                           }
@@ -2113,8 +2116,7 @@ viewConfig ({ params, paramsForm, paramsInfo, notSeenLogs, registeredImages } as
                         ]
                     , moreInfo paramsInfo.levels "The number of levels for the multi-resolution approach. Each level halves/doubles the resolution of the previous one. The algorithm starts at the lowest resolution and transfers the converged parameters at one resolution to the initialization of the next. Increasing the number of levels enables better convergence for bigger movements but too many levels might make it definitively drift away. Targetting a lowest resolution of about 100x100 is generally good enough. The number of levels also has a joint interaction with the sparse threshold parameter so keep that in mind while changing this parameter."
 
-                    -- , Element.text ("(default to " ++ String.fromInt defaultParams.levels ++ ")")
-                    -- /!\ Default number of pyramids removed in order to put a fitting number of pyramids
+                    , Element.text ("(default to " ++ String.fromInt model.paramsForm.defaultLevels ++ ")")
                     , intInput paramsForm.levels (ParamsMsg << ChangeLevels) "Number of pyramid levels"
                     , displayIntErrors paramsForm.levels.decodedInput
                     ]

--- a/web-elm/src/Main.elm
+++ b/web-elm/src/Main.elm
@@ -546,7 +546,8 @@ update msg model =
                     , loaded = newLoaded
                     }
 
-                finished = (Set.size names == Dict.size newLoaded)
+                finished =
+                    Set.size names == Dict.size newLoaded
 
                 oldParamsForm =
                     model.paramsForm
@@ -554,9 +555,12 @@ update msg model =
                 oldParams =
                     model.params
 
-                optiLevels = if finished
-                    then getOptimumPyramids newLoaded
-                    else model.params.levels
+                optiLevels =
+                    if finished then
+                        getOptimumPyramids newLoaded
+
+                    else
+                        model.params.levels
 
                 anyInt =
                     NumberInput.intDefault
@@ -2115,7 +2119,6 @@ viewConfig ({ params, paramsForm, paramsInfo, notSeenLogs, registeredImages } as
                             }
                         ]
                     , moreInfo paramsInfo.levels "The number of levels for the multi-resolution approach. Each level halves/doubles the resolution of the previous one. The algorithm starts at the lowest resolution and transfers the converged parameters at one resolution to the initialization of the next. Increasing the number of levels enables better convergence for bigger movements but too many levels might make it definitively drift away. Targetting a lowest resolution of about 100x100 is generally good enough. The number of levels also has a joint interaction with the sparse threshold parameter so keep that in mind while changing this parameter."
-
                     , Element.text ("(default to " ++ String.fromInt model.paramsForm.defaultLevels ++ ")")
                     , intInput paramsForm.levels (ParamsMsg << ChangeLevels) "Number of pyramid levels"
                     , displayIntErrors paramsForm.levels.decodedInput


### PR DESCRIPTION
# Automatic fil for the pyramids level

We want our images to go to a minimal resolution of **100x100px** at the top of the pyramid.
Each level divides the resolution by two.

Let <img src="https://render.githubusercontent.com/render/math?math=h^i"> be the height of the ith image, and <img src="https://render.githubusercontent.com/render/math?math=w^i"> its width.

Then, let <img src="https://render.githubusercontent.com/render/math?math=h=\min_{i\le N}h^i"> and  <img src="https://render.githubusercontent.com/render/math?math=w=\min_{i\le N}w^i">.

Then the sequence of the steps of the pyramid for this minimal image is a geometric sequence, which writes : <img src="https://render.githubusercontent.com/render/math?math=h_n=\frac{h}{2^n}>100"> and <img src="https://render.githubusercontent.com/render/math?math=w_n=\frac{w}{2^n}>100">

As we want a single n integer value for both height and width for all images, we choose the following formula :
<img style="border : 5px solid black;" src="https://render.githubusercontent.com/render/math?math=n=\left\lfloor log_2(min(h,w)/100)\right\rfloor">.
The floor function helps us providing safety, avoiding to go further than 100 at the top stage of the pyramid.

For most good quality pictures, this corresponds to 4 levels. For minimal resolutions higher than `3200px`, we have 5 of them.
Lower than that, we usually have 2 or 3 levels.

The old `levels` field from `defaultParams` and `defaultParamsForm` has not been taken out of the code, but I chose to put them at `1` just in case. No important effects on the code imho.